### PR TITLE
High level idea to remove queue

### DIFF
--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -101,15 +101,15 @@ module Puma
                 end
               elsif idx == 0 # restart server
                 log "wrkr-fork restart server\n"
-                restart_server << true << false
+                restart_server << "restart" << "stopped"
               else
                 # fork worker
                 log "wrkr-fork fork-worker idx:#{idx}\n"
 
                 # new methods, we only queue for later
                 if use_same_thread
-                  new_workers << idx
-                  restart_server << true << false
+                  # new_workers << idx
+                  restart_server << "spawn#{idx}" << "stopped"
                 else
                   # previously, we spawn worker when we recv signals
                   worker_pids << pid = spawn_worker(idx)
@@ -126,7 +126,7 @@ module Puma
           @worker_write << "#{Puma::Const::PipeRequest::EXTERNAL_TERM}#{Process.pid}\n" rescue nil
           restart_server.clear
           server.stop
-          restart_server << false
+          restart_server << "stopped"
         end
 
         begin
@@ -137,15 +137,18 @@ module Puma
           return
         end
 
-        while restart_server.pop
+        while (cmd = restart_server.pop) != "stopped"
           log "restart_server idx:#{index}-pid:#{Process.pid}\n"
 
-          if fork_worker && use_same_thread
-            new_worker_pids = spawn_workers(new_workers)
+          if fork_worker && use_same_thread && cmd.start_with?("spawn")
+            idx = cmd.split("spawn").last.to_i
+            # new_worker_pids = spawn_workers(new_workers)
+            new_worker_pids = [spawn_worker(idx)]
             log "new_worker_pids: #{new_worker_pids}\n"
             worker_pids.concat(new_worker_pids) unless new_worker_pids.nil?
             log "worker_pids: #{worker_pids}\n"
-            next if new_worker_pids.size != 0
+
+            next
           end
 
           begin

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -139,11 +139,8 @@ module Puma
           return
         end
 
-        while (cmd = restart_server.pop)
-
+        while (cmd = restart_server.pop) != Puma::Const::WorkerCmd::STOPPED
           log "cmd:#{cmd}\n"
-          break if cmd == Puma::Const::WorkerCmd::STOPPED
-
           log "restart_server idx:#{index}-pid:#{Process.pid}\n"
 
           if fork_worker && use_same_thread && cmd.start_with?(Puma::Const::WorkerCmd::SPAWN)

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -109,7 +109,7 @@ module Puma
                 # new methods, we only queue for later
                 if use_same_thread
                   # new_workers << idx
-                  restart_server << "spawn#{idx}" << "stopped"
+                  restart_server << "spawn#{idx}"
                 else
                   # previously, we spawn worker when we recv signals
                   worker_pids << pid = spawn_worker(idx)

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -119,8 +119,8 @@ module Puma
 
           if fork_worker && cmd.start_with?(Puma::Const::WorkerCmd::SPAWN)
             idx = cmd.split(Puma::Const::WorkerCmd::SPAWN).last.to_i
-            new_worker_pids = [spawn_worker(idx)]
-            worker_pids.concat(new_worker_pids) unless new_worker_pids.nil?
+            child_pid = spawn_worker(idx)
+            worker_pids << child_pid unless child_pid.nil?
 
             next
           end

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -56,7 +56,6 @@ module Puma
         # things in shape before booting the app.
         @config.run_hooks(:before_worker_boot, index, @log_writer, @hook_data)
 
-        log "@server.nil?: #{@server.nil?}\n"
         begin
           server = @server ||= start_server
         rescue Exception => e
@@ -153,6 +152,7 @@ module Puma
             end
           end
 
+          log "Server started - worker #{index}" if @log_writer.debug?
           server_thread.join
         end
 

--- a/lib/puma/cluster/worker.rb
+++ b/lib/puma/cluster/worker.rb
@@ -93,9 +93,10 @@ module Puma
                 log "wrkr-fork stop server\n"
                 if restart_server.length > 0
                   log "stopping server: #{idx}\n"
+                  log "server status: #{server.instance_variable_get("@status")}\n"
                   restart_server.clear
                   server.begin_restart(true)
-                  log "queue size at shutting down:#{restart_server.length}\n"
+                  log "queue size at shutting down:#{restart_server.length} at now: #{Time.now.to_f}\n"
                   @config.run_hooks(:before_refork, nil, @log_writer, @hook_data)
                 end
               elsif idx == 0 # restart server
@@ -156,10 +157,9 @@ module Puma
             next
           end
 
-          log "attempt run server idx:#{index}-pid:#{Process.pid}\n"
+          log ">>> begin run_server idx:#{index}-pid:#{Process.pid} at now: #{Time.now.to_f}\n"
           server_thread = server.run
-          log "server.run idx:#{index}-pid:#{Process.pid}\n"
-          log "queue size at server shutdown: #{restart_server.length}\n"
+          log ">>> end run_server idx:#{index}-pid:#{Process.pid} at now: #{Time.now.to_f}\n"
 
           if @log_writer.debug? && index == 0
             debug_loaded_extensions "Loaded Extensions - worker 0:"
@@ -186,7 +186,8 @@ module Puma
             end
           end
 
-          log "sever_thread about to join: queue size: #{restart_server.length}\n"
+          # it takes about 5ms from run server to join
+          log "sever_thread about to join: queue size: #{restart_server.length} now: #{Time.now.to_f}\n"
           server_thread.join
           log "sever_thread finish join"
         end

--- a/lib/puma/const.rb
+++ b/lib/puma/const.rb
@@ -303,5 +303,11 @@ module Puma
       PING = "p"
       IDLE = "i"
     end
+
+    module WorkerCmd
+      RESTART = "restart"
+      STOPPED = "stopped"
+      SPAWN = "spawn"
+    end
   end
 end

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -304,7 +304,7 @@ class TestIntegrationCluster < TestIntegration
       on_refork { File.write '#{refork.path}', 'Reforked' }
     CONFIG
 
-    pids = get_worker_pids 0, wrkrs, log: true
+    pids = get_worker_pids 0, wrkrs
 
     socks = []
     until refork.read == 'Reforked'
@@ -319,7 +319,7 @@ class TestIntegrationCluster < TestIntegration
 
     socks.each { |s| read_body s }
 
-    refute_includes pids, get_worker_pids(1, wrkrs - 1,log: true)
+    refute_includes pids, get_worker_pids(1, wrkrs - 1)
   end
 
   def test_fork_worker_spawn

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -304,7 +304,7 @@ class TestIntegrationCluster < TestIntegration
       on_refork { File.write '#{refork.path}', 'Reforked' }
     CONFIG
 
-    pids = get_worker_pids 0, wrkrs
+    pids = get_worker_pids 0, wrkrs, log:true
 
     socks = []
     until refork.read == 'Reforked'

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -472,18 +472,17 @@ class TestIntegrationCluster < TestIntegration
   end
 
   def test_culling_strategy_oldest_fork_worker
-    cli_server "-w 2 test/rackup/hello.ru", config: <<~CONFIG
+    cli_server "-w 2 test/rackup/hello.ru", puma_debug: true, config: <<~CONFIG
       worker_culling_strategy :oldest
       fork_worker
     CONFIG
 
-    get_worker_pids(log: true) # to consume server logs
-
-    sleep(5) # testing only, try to debug potential race-condition
+    get_worker_pids # to consume server logs
+    assert wait_for_server_to_match(/Server started - worker 0/) # ensure server is started for worker-0
 
     Process.kill :TTIN, @pid
 
-    assert wait_for_server_to_match(/Worker 2 \(PID: \d+\) booted in/, log: true, timeout: 40)
+    assert wait_for_server_to_match(/Worker 2 \(PID: \d+\) booted in/)
 
     Process.kill :TTOU, @pid
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -304,7 +304,7 @@ class TestIntegrationCluster < TestIntegration
       on_refork { File.write '#{refork.path}', 'Reforked' }
     CONFIG
 
-    pids = get_worker_pids 0, wrkrs
+    pids = get_worker_pids 0, wrkrs, log:true
 
     socks = []
     until refork.read == 'Reforked'
@@ -319,7 +319,7 @@ class TestIntegrationCluster < TestIntegration
 
     socks.each { |s| read_body s }
 
-    refute_includes pids, get_worker_pids(1, wrkrs - 1)
+    refute_includes pids, get_worker_pids(1, wrkrs - 1,log:true)
   end
 
   def test_fork_worker_spawn
@@ -478,6 +478,8 @@ class TestIntegrationCluster < TestIntegration
     CONFIG
 
     get_worker_pids(log: true) # to consume server logs
+
+    sleep(5) # testing only, try to debug potential race-condition
 
     Process.kill :TTIN, @pid
 

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -304,7 +304,7 @@ class TestIntegrationCluster < TestIntegration
       on_refork { File.write '#{refork.path}', 'Reforked' }
     CONFIG
 
-    pids = get_worker_pids 0, wrkrs, log:true
+    pids = get_worker_pids 0, wrkrs, log: true
 
     socks = []
     until refork.read == 'Reforked'
@@ -319,7 +319,7 @@ class TestIntegrationCluster < TestIntegration
 
     socks.each { |s| read_body s }
 
-    refute_includes pids, get_worker_pids(1, wrkrs - 1,log:true)
+    refute_includes pids, get_worker_pids(1, wrkrs - 1,log: true)
   end
 
   def test_fork_worker_spawn

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -304,7 +304,7 @@ class TestIntegrationCluster < TestIntegration
       on_refork { File.write '#{refork.path}', 'Reforked' }
     CONFIG
 
-    pids = get_worker_pids 0, wrkrs, log:true
+    pids = get_worker_pids 0, wrkrs
 
     socks = []
     until refork.read == 'Reforked'

--- a/test/test_integration_cluster.rb
+++ b/test/test_integration_cluster.rb
@@ -477,11 +477,11 @@ class TestIntegrationCluster < TestIntegration
       fork_worker
     CONFIG
 
-    get_worker_pids # to consume server logs
+    get_worker_pids(log: true) # to consume server logs
 
     Process.kill :TTIN, @pid
 
-    assert wait_for_server_to_match(/Worker 2 \(PID: \d+\) booted in/)
+    assert wait_for_server_to_match(/Worker 2 \(PID: \d+\) booted in/, log: true, timeout: 40)
 
     Process.kill :TTOU, @pid
 


### PR DESCRIPTION
### Description
It's likely a separate queue to store spawn worker IDs will lead to race-condition; hence I'm exploring the option to remove the queue by changing the worker's restart server loop control flow to accept command enum instead of binary bool. 

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
